### PR TITLE
Fixed hanging bug

### DIFF
--- a/inf_od_nwk.py
+++ b/inf_od_nwk.py
@@ -134,6 +134,7 @@ if __name__ == '__main__':
 
 	        # send grasp coordinates to external server for processing
             # request should return an arm configuration
+            '''
             data_packet = [gripper_pt1_arm.tolist(), gripper_pt2_arm.tolist()]
             robot.send_data(data_packet)
 
@@ -142,7 +143,10 @@ if __name__ == '__main__':
             print(arm_config)
 
             # send arm_config to the arm to move
-
+            '''
             if key & 0xFF == ord('q') or key == 27:
                 cv2.destroyAllWindows()
                 break
+            if key & 0xFF == ord('r'):
+                cv2.destroyAllWindows()
+


### PR DESCRIPTION
Fixed the bug that caused the inf_od_nwk.py integration file to fail after one iteration. In order to start the new iteration, instead of closing all the windows, press 'r'. To quit completely out of the loop, press 'q' or the Esc key. 